### PR TITLE
Corrección de rutas de scripts en plantilla_backlog.html

### DIFF
--- a/vista/plantilla_backlog.html
+++ b/vista/plantilla_backlog.html
@@ -104,12 +104,12 @@
         </div>
     </div>
     
-	<script src="HistoriaHelper.js"></script>
-	<script src="DBBacklogQuery.js"></script>
-	<script src="BacklogViewModel.js"></script>
-	<script src="InfoHistoriaView.js"></script>
-	<script src="HistoriaView.js"></script>
-	<script src="BacklogView.js"></script>
+	<script src="vista/HistoriaHelper.js"></script>
+	<script src="vista/DBBacklogQuery.js"></script>
+	<script src="vista/BacklogViewModel.js"></script>
+	<script src="vista/InfoHistoriaView.js"></script>
+	<script src="vista/HistoriaView.js"></script>
+	<script src="vista/BacklogView.js"></script>
 	<script>
 		InfoHistoriaView.init();
 		BacklogView.init();


### PR DESCRIPTION
Las rutas estaban como &lt;script src="HistoriaHelper.js">&lt;/script>, cuando deberían estar como &lt;script src="vista/HistoriaHelper.js">&lt;/script>
